### PR TITLE
Fix clipped last char of string.

### DIFF
--- a/extmod/ugfx/src/gdisp/gdisp.c
+++ b/extmod/ugfx/src/gdisp/gdisp.c
@@ -3231,7 +3231,7 @@ void gdispGDrawBox(GDisplay *g, coord_t x, coord_t y, coord_t cx, coord_t cy, co
 		g->t.font = font;
 		g->t.clipx0 = x;
 		g->t.clipy0 = y;
-		g->t.clipx1 = x + mf_get_string_width(font, str, 0, 0);
+		g->t.clipx1 = x + mf_get_string_width(font, str, 0, 0) + 2; // +2 Fixes clipped last char of string. 
 		g->t.clipy1 = y + font->height;
 		g->t.color = color;
 


### PR DESCRIPTION
See "Select App to start" in official launcher. The last letter "t" is clipped on the right side. Something about the calculation of the string width is off by two. This seemed like the only way I could find to 'fix' it.